### PR TITLE
Create MIP package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "urls": [
+    [
+      "lib/i2c_lcd.py",
+      "github:ubidefeo/micropython-i2c-lcd/lib/i2c_lcd.py"
+    ],
+    [
+      "lib/i2c_lcd_backlight.py",
+      "github:ubidefeo/micropython-i2c-lcd/lib/i2c_lcd_backlight.py"
+    ],
+    [
+      "lib/i2c_lcd_screen.py",
+      "github:ubidefeo/micropython-i2c-lcd/lib/i2c_lcd_screen.py"
+    ]
+  ],
+  "deps": [],
+  "version": "2.0.0"
+}


### PR DESCRIPTION
This PR enables installation through mip. Following the code in the examples, it assumes that the files are installed directly under `/lib`. If we want the files to go in a subfolder, it needs to be changed in the examples too.